### PR TITLE
Removed (almost) all Try examples in documentation/comment blocks

### DIFF
--- a/docs/_data/sidebar-core.yml
+++ b/docs/_data/sidebar-core.yml
@@ -62,9 +62,6 @@ options:
       - title: Either
         url: /apidocs/arrow-core-data/arrow.core/-either/
 
-      - title: Try
-        url: /apidocs/arrow-core-data/arrow.core/-try/
-
       - title: Validated
         url: /apidocs/arrow-core-data/arrow.core/-validated/
 


### PR DESCRIPTION
Original PR can be seen [here](https://github.com/arrow-kt/arrow-core/issues/26).

What version are you currently using? 0.10

What would you like to see?
The documentation includes Try examples. Since Try is deprecated, these examples should be removed (or transitioned to Either examples) to prevent confusion.