### PR TITLE
Modifications to the documentation version links

### DIFF
--- a/docs/_includes/_sidebar-doc-versions.html
+++ b/docs/_includes/_sidebar-doc-versions.html
@@ -1,11 +1,4 @@
-{% assign doc-link = 'core/' %}
-{% if cat_id == 'incubator' %}
-{% assign doc-link = 'aql/intro/' %}
-{% elsif cat_id  == 'fx' %}
-{% assign doc-link = 'fx/' %}
-{% elsif cat_id  == 'optics' %}
-{% assign doc-link = 'optics/dsl/' %}
-{% endif %}
+{% assign current_url = page.url | remove_first: '/' %}
 
 <ul class="sidebar-nav sidebar-doc-versions">
   <li id="doc-version-dropdown" class="sidebar-nav-item">
@@ -16,7 +9,7 @@
     </a>
     <ul>
       <li>
-        <a href="{{ site.data.commons.stable_version | append: doc-link }}">
+        <a href="{{ site.data.commons.stable_version | append: current_url }}">
           <span>
             {{ stable_version.title }} - {{ site.data.doc-versions.stable }}
           </span>
@@ -24,7 +17,7 @@
       </li>
 
       <li>
-        <a href="{{ next_version.url | append: doc-link }}">
+        <a href="{{ next_version.url | append: current_url }}">
           <span>
             {{ next_version.title }} - {{ site.data.doc-versions.next }}
           </span>


### PR DESCRIPTION
Changes the doc version links to point to the actual url the user is on.

We should analyze and anticipate to every possible scenario this PR will bring before going on with this changes. This must to controll from AWS the 404 cases for every Arrow site version.
After this analysis we could decide if it´s a good option or if we should leave it as it is right now.

closes #11 