### PR TITLE
Fix URLs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         JAVA_OPTS: -Xms512m -Xmx1024m
         JEKYLL_ENV: production
       run: |
-        bundle exec jekyll build -b docs -s build/site -d build/_site
+        bundle exec jekyll build -s build/site -d build/_site
         mkdir $BASEDIR/logs
         tree build/_site > $BASEDIR/logs/docs.log
     - name: Generate and validate docs for all the libraries

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
         JAVA_OPTS: -Xms512m -Xmx1024m
         JEKYLL_ENV: production
       run: |
-        bundle exec jekyll build -b docs -s build/site -d build/_site
+        bundle exec jekyll build -s build/site -d build/_site
         mkdir $BASEDIR/logs
         tree build/_site > $BASEDIR/logs/docs.log
     - name: Publish site

--- a/docs/_data/features.yml
+++ b/docs/_data/features.yml
@@ -2,19 +2,19 @@ content:
     - title: Arrow Core
       description: Arrow is the functional companion to Kotlin's Standard Library
       icon: img/home/arrow-core-lines
-      url: /core/
+      url: /docs/core/
       id: core
 
     - title: Arrow FX
       description: Arrow FX is a next-generation Typed FP Effects Library built to tame side effectful APIs
       icon: img/home/arrow-fx-lines
-      url: /fx/
+      url: /docs/fx/
       id: fx
 
     - title: Arrow Optics
       description: Arrow Optics helps by transforming and computing over immutable data models in Kotlin
       icon: img/home/arrow-optics-lines
-      url: /optics/dsl/
+      url: /docs/optics/dsl/
       id: optics
 
     - title: Arrow Meta
@@ -26,21 +26,21 @@ content:
     - title: Arrow Incubator
       description:
       icon:
-      url: /aql/intro/
+      url: /docs/aql/intro/
       id: incubator
 
 incubator:
     - title: Arrow Query Language
-      url: /aql/intro/
+      url: /docs/aql/intro/
 
     - title: Arrow Generic
-      url: /generic/product/
+      url: /docs/generic/product/
 
     - title: Arrow Free
-      url: /free/free/
+      url: /docs/free/free/
 
     - title: Recursion Schemes
-      url: /recursion/intro/
+      url: /docs/recursion/intro/
 
     - title: MTL
-      url: /apidocs/arrow-mtl/
+      url: /docs/apidocs/arrow-mtl/


### PR DESCRIPTION
@franciscodr, @AntonioMateoGomez , I add `/docs` in landing page links to be able to generate the root content without `-b docs` because JS and CSS aren't found with that option.