### PR TITLE
Fix doc version links

### DIFF
--- a/docs/_includes/_sidebar-doc-versions.html
+++ b/docs/_includes/_sidebar-doc-versions.html
@@ -16,7 +16,8 @@
     </a>
     <ul>
       <li>
-        <a href="{{ site.data.commons.stable_version | append: doc-link }}">
+        {% assign stable_base_doc_link = site.data.commons.stable_version | append: 'docs/' %}
+        <a href="{{ stable_base_doc_link | append: doc-link }}">
           <span>
             {{ stable_version.title }} - {{ site.data.doc-versions.stable }}
           </span>

--- a/docs/_sass/components/common/_button.scss
+++ b/docs/_sass/components/common/_button.scss
@@ -59,6 +59,7 @@
 
 // Slack channel link button
 .slack-link-container {
+  z-index: 2;
   position: fixed;
   bottom: $base-point-grid;
   right: ($base-point-grid * 2);


### PR DESCRIPTION
Fixes stable version link in the doc version selector. Also adds z-index to the slack channel link container.