### PR TITLE
Paolo fix sidebar module selector

### DIFF
--- a/docs/_includes/_sidebar-cat-dropdown.html
+++ b/docs/_includes/_sidebar-cat-dropdown.html
@@ -8,10 +8,11 @@
       </a>
       <ul>
         {% for item in site.data.features.content %}
+        {% assign cat_url = item.url | remove_first: '/docs' %}
         {% assign cat = item.title | downcase  %}
         {% if cat != cat_title %}
         <li>
-          <a href="{{ item.url | relative_url }}">
+          <a href="{{ cat_url | relative_url }}">
             <span>{{ item.title }}</span>
           </a>
         </li>

--- a/docs/_includes/_sidebar-doc-versions.html
+++ b/docs/_includes/_sidebar-doc-versions.html
@@ -1,3 +1,12 @@
+{% assign doc-link = 'core/' %}
+{% if cat_id == 'incubator' %}
+{% assign doc-link = 'aql/intro/' %}
+{% elsif cat_id  == 'fx' %}
+{% assign doc-link = 'fx/' %}
+{% elsif cat_id  == 'optics' %}
+{% assign doc-link = 'optics/dsl/' %}
+{% endif %}
+
 <ul class="sidebar-nav sidebar-doc-versions">
   <li id="doc-version-dropdown" class="sidebar-nav-item">
     <a href="#">

--- a/docs/_includes/_sidebar-doc-versions.html
+++ b/docs/_includes/_sidebar-doc-versions.html
@@ -1,12 +1,3 @@
-{% assign doc-link = 'core/' %}
-{% if cat_id == 'incubator' %}
-{% assign doc-link = 'aql/intro/' %}
-{% elsif cat_id  == 'fx' %}
-{% assign doc-link = 'fx/' %}
-{% elsif cat_id  == 'optics' %}
-{% assign doc-link = 'optics/dsl/' %}
-{% endif %}
-
 <ul class="sidebar-nav sidebar-doc-versions">
   <li id="doc-version-dropdown" class="sidebar-nav-item">
     <a href="#">

--- a/docs/_includes/_sidebar-wrapper.html
+++ b/docs/_includes/_sidebar-wrapper.html
@@ -1,3 +1,14 @@
+{% assign doc-link = 'core/' %}
+{% if cat_id == 'incubator' %}
+{% assign doc-link = 'aql/intro/' %}
+{% elsif cat_id  == 'fx' %}
+{% assign doc-link = 'fx/' %}
+{% elsif cat_id  == 'optics' %}
+{% assign doc-link = 'optics/dsl/' %}
+{% endif %}
+
+{% assign cat_base_url =  base_url | append: doc-link %}
+
 <div id="sidebar-wrapper" class="{{ cat_id }}">
   <div class="toggle-container">
     <button type="button" id="main-toggle" class="sidebar-toggle">
@@ -5,7 +16,7 @@
     </button>
   </div>
   <div class="sidebar-brand">
-    <a href="{{ '/' | relative_url }}">
+    <a href="{{ cat_base_url | relative_url }}">
       {% assign img_url = '/img/' | append: cat_id | append: '/arrow-' | append: cat_id | append: '-brand-sidebar.svg' %}
       <img src="{{ img_url | relative_url}}" alt="Arrow {{ cat_id }}">
     </a>

--- a/docs/_includes/_sidebar-wrapper.html
+++ b/docs/_includes/_sidebar-wrapper.html
@@ -1,14 +1,3 @@
-{% assign doc-link = 'core/' %}
-{% if cat_id == 'incubator' %}
-{% assign doc-link = 'aql/intro/' %}
-{% elsif cat_id  == 'fx' %}
-{% assign doc-link = 'fx/' %}
-{% elsif cat_id  == 'optics' %}
-{% assign doc-link = 'optics/dsl/' %}
-{% endif %}
-
-{% assign cat_base_url =  base_url | append: doc-link %}
-
 <div id="sidebar-wrapper" class="{{ cat_id }}">
   <div class="toggle-container">
     <button type="button" id="main-toggle" class="sidebar-toggle">
@@ -16,7 +5,7 @@
     </button>
   </div>
   <div class="sidebar-brand">
-    <a href="{{ cat_base_url | relative_url }}">
+    <a href="{{ site.data.commons.stable_version | relative_url }}">
       {% assign img_url = '/img/' | append: cat_id | append: '/arrow-' | append: cat_id | append: '-brand-sidebar.svg' %}
       <img src="{{ img_url | relative_url}}" alt="Arrow {{ cat_id }}">
     </a>


### PR DESCRIPTION
This PR fixes the module selector links since the source file to compose those links has been changed adding in every link `docs/`
Also modifies the icon link in this secction that now points to `https://arrow-kt.io/` correctly.