### PR TITLE
Set sticky position in small size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,8 @@ fabric.properties
 # Jekyll
 _site
 .sass-cache
+/vendor
+/.bundle
 
 #Ruby
 Gemfile.lock

--- a/docs/_sass/components/docs/_doc-header.scss
+++ b/docs/_sass/components/docs/_doc-header.scss
@@ -89,3 +89,13 @@
     }
   }
 }
+
+@include bp(medium) {
+  #doc-wrapper {
+    .doc-header {
+      position: sticky;
+      top: 0;
+      z-index: 2;
+    }
+  }
+}


### PR DESCRIPTION
Sets `doc-header` sticky position in small screen size for docs section.

This closes #35 