### PR TITLE
Fix #47. Filter pages at sitemap

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,7 +143,7 @@ jobs:
         echo '<?xml version="1.0" encoding="UTF-8"?>' > sitemap.xml
         echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' >> sitemap.xml
         aws s3 ls s3://$S3_BUCKET/docs/$LAST_MAJOR_MINOR_VERSION --recursive > docs-content.log
-        grep html docs-content.log > docs-pages.log
+        grep index.html docs-content.log > docs-pages.log
         while read line; do
           PAGE_DATE=$(echo $line | cut -d' ' -f1)
           PAGE_PATH=$(echo $line | cut -d' ' -f4)


### PR DESCRIPTION
The new configuration provided to Algolia team is working. However, search results by `Option` include `option` properties like https://arrow-kt.io/docs/0.10/apidocs/arrow-meta-test-models/arrow.ap.objects.optional/-optional-sealed/option.html

This PR removes that kind of pages from the sitemap.

Note. Maybe the new search results are shown before merging this PR because sitemap was updated during the test.