### PR TITLE
Configuration: Avoid adding a new module if it follows a pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ Go to `docs/_data/` and choose the correspondent `sidebar-x.yml` file. Then, add
   url: /typeclasses/applicative/
 ```
 
-Check [this PR](https://github.com/arrow-kt/arrow/pull/1134/files) for a real example.
+### How to choose the style for an Arrow module
+
+Is a page showing a wrong style? For instance, is an Arrow Incubator page showing the style of Arrow Core?
+
+Please, add that module in `docs/_config.yml` and choose the right `layout`.
+
+If the module starts with `arrow-optics-` or `arrow-fx-` will show the right style by default.
 
 ### How to deploy the site to a local server
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -27,32 +27,12 @@ collections:
 # Default Front Matter values to be set
 defaults:
   - scope:
-      path: "apidocs/arrow-optics-mtl"
+      path: "apidocs/arrow-optics*"
       type: "pages"
     values:
       layout: "docs-optics"
   - scope:
-      path: "apidocs/arrow-optics"
-      type: "pages"
-    values:
-      layout: "docs-optics"
-  - scope:
-      path: "apidocs/arrow-fx-mtl"
-      type: "pages"
-    values:
-      layout: "docs-fx"
-  - scope:
-      path: "apidocs/arrow-fx-reactor"
-      type: "pages"
-    values:
-      layout: "docs-fx"
-  - scope:
-      path: "apidocs/arrow-fx-rx2"
-      type: "pages"
-    values:
-      layout: "docs-fx"
-  - scope:
-      path: "apidocs/arrow-fx"
+      path: "apidocs/arrow-fx*"
       type: "pages"
     values:
       layout: "docs-fx"


### PR DESCRIPTION
@calvellido , @AntonioMateoGomez , it's possible to use a glob pattern since 3.7.0 https://jekyllrb.com/docs/configuration/front-matter-defaults/#glob-patterns-in-front-matter-defaults and we're using:

```
gem "jekyll", "~> 3.7.3"
```

I checked it and it works!

cc @nomisRev , this change avoids adding `arrow-fx-coroutines` in `docs/_config.yml`