### PR TITLE
Fix docs header z-index.

### DIFF
--- a/docs/_sass/components/docs/_doc-header.scss
+++ b/docs/_sass/components/docs/_doc-header.scss
@@ -95,7 +95,7 @@
     .doc-header {
       position: sticky;
       top: 0;
-      z-index: 2;
+      z-index: 4;
     }
   }
 }


### PR DESCRIPTION
Fixes the header z-index for mobile screens. 

Note: I choose `z-index: 4` since `.CodeMirror-gutters` (inside the code block) already has a `z-index` of `3`.

### Before:
![Screen Shot 2020-08-14 at 10 54 57](https://user-images.githubusercontent.com/17609157/90257066-0951e000-de1d-11ea-9071-976aa6fd9d2f.png)


### After:
![Screen Shot 2020-08-14 at 10 54 34](https://user-images.githubusercontent.com/17609157/90257084-0eaf2a80-de1d-11ea-82cb-9579b173927b.png)
