### PR TITLE
Update sidebar: new module and fix format

### DIFF
--- a/docs/_data/sidebar-core.yml
+++ b/docs/_data/sidebar-core.yml
@@ -279,6 +279,9 @@ options:
       - title: Core Extensions
         url: /apidocs/arrow-core-data/
 
+      - title: Core Retrofit
+        url: /apidocs/arrow-core-retrofit/
+
       - title: Integrations Retrofit Adapter
         url: /apidocs/arrow-integrations-retrofit-adapter/
 

--- a/docs/_data/sidebar-fx.yml
+++ b/docs/_data/sidebar-fx.yml
@@ -17,25 +17,25 @@ options:
     nested_options:
 
       - title: Atomic
-        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-atomic
+        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-atomic/
 
       - title: ConcurrentVar
-        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-concurrent-var
+        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-concurrent-var/
 
       - title: Resource
-        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-resource
+        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-resource/
 
       - title: Schedule
-        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-schedule
+        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-schedule/
 
       - title: CircuitBreaker
-        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-circuit-breaker
+        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-circuit-breaker/
 
       - title: Promise
-        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-promise
+        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-promise/
 
       - title: Semaphore
-        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-semaphore
+        url: /apidocs/arrow-fx-coroutines/arrow.fx.coroutines/-semaphore/
 
   - title: Integrations
 


### PR DESCRIPTION
- Add `arrow-core-retrofit`
- Fix format (it solves a problem with the new menu entries because the menu doesn't keep the selected data type cc: @nomisRev)