### PR TITLE
Fix previous version link

### DIFF
--- a/docs/_includes/_sidebar-doc-versions.html
+++ b/docs/_includes/_sidebar-doc-versions.html
@@ -33,7 +33,7 @@
       </li>
 
       <li>
-        <a href="{{ previous_version.url }}">
+        <a href="{{ previous_version.url | append: doc-link }}">
           <span>
             {{ previous_version.title }} - {{ site.data.doc-versions.previous }}
           </span>


### PR DESCRIPTION
**Reason**: the previous version is `0.10.5` instead of `0.9` now. That version follows the new organization.