### PR TITLE
Upgrade Jekyll to 4.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,35 +39,35 @@ jobs:
         rm -f docs/index.md
         bundle exec jekyll build -b docs/next -s docs
         tree _site > $BASEDIR/logs/content_docs-next.log
-    - name: "Latest release: generate and validate docs for all the libraries"
-      run: |
-        export VERSION=$(grep LATEST_VERSION $BASEDIR/arrow-master/gradle.properties | cut -d= -f2)
-        git clone https://github.com/arrow-kt/arrow-site.git $BASEDIR/arrow-site-$VERSION
-        LAST_TAG=$(git tag -l --sort=version:refname ${VERSION}* | tail -1)
-        echo ">> Last tag: $LAST_TAG"
-        cd $BASEDIR/arrow-site-$VERSION; git checkout $LAST_TAG; cd -
-        ./scripts/generate-and-validate-doc.sh
-    - name: "Latest release: build"
-      run: |
-        bundle exec jekyll build -b docs -s docs
-        tree _site > $BASEDIR/logs/content_docs.log
-    - name: "Other versions: generate and validate docs for all the libraries"
-      run: |
-        if [ -f $BASEDIR/arrow-site/update-other-versions.txt ]; then
-            for version in $(cat update-other-versions.txt); do
-                export VERSION=$version
-                export SHORT_VERSION=$(echo $VERSION | cut -d. -f1-2)
-                git clone https://github.com/arrow-kt/arrow-site.git $BASEDIR/arrow-site-$VERSION
-                LAST_TAG=$(git tag -l --sort=version:refname ${VERSION}* | tail -1)
-                echo ">> Last tag: $LAST_TAG"
-                cd $BASEDIR/arrow-site-$VERSION; git checkout $LAST_TAG; cd -
-                ./scripts/generate-and-validate-doc.sh
-                cd $BASEDIR/arrow-site
-                rm -f docs/index.md
-                bundle exec jekyll build -b docs/$SHORT_VERSION -s docs
-                tree _site > $BASEDIR/logs/content_docs-${SHORT_VERSION}.log
-            done
-        fi
+    #- name: "Latest release: generate and validate docs for all the libraries"
+    #  run: |
+    #    export VERSION=$(grep LATEST_VERSION $BASEDIR/arrow-master/gradle.properties | cut -d= -f2)
+    #    git clone https://github.com/arrow-kt/arrow-site.git $BASEDIR/arrow-site-$VERSION
+    #    LAST_TAG=$(git tag -l --sort=version:refname ${VERSION}* | tail -1)
+    #    echo ">> Last tag: $LAST_TAG"
+    #    cd $BASEDIR/arrow-site-$VERSION; git checkout $LAST_TAG; cd -
+    #    ./scripts/generate-and-validate-doc.sh
+    #- name: "Latest release: build"
+    #  run: |
+    #    bundle exec jekyll build -b docs -s docs
+    #    tree _site > $BASEDIR/logs/content_docs.log
+    #- name: "Other versions: generate and validate docs for all the libraries"
+    #  run: |
+    #    if [ -f $BASEDIR/arrow-site/update-other-versions.txt ]; then
+    #        for version in $(cat update-other-versions.txt); do
+    #            export VERSION=$version
+    #            export SHORT_VERSION=$(echo $VERSION | cut -d. -f1-2)
+    #            git clone https://github.com/arrow-kt/arrow-site.git $BASEDIR/arrow-site-$VERSION
+    #            LAST_TAG=$(git tag -l --sort=version:refname ${VERSION}* | tail -1)
+    #            echo ">> Last tag: $LAST_TAG"
+    #            cd $BASEDIR/arrow-site-$VERSION; git checkout $LAST_TAG; cd -
+    #            ./scripts/generate-and-validate-doc.sh
+    #            cd $BASEDIR/arrow-site
+    #            rm -f docs/index.md
+    #            bundle exec jekyll build -b docs/$SHORT_VERSION -s docs
+    #            tree _site > $BASEDIR/logs/content_docs-${SHORT_VERSION}.log
+    #        done
+    #    fi
     - uses: actions/upload-artifact@v1
       with:
         name: logs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,41 +52,41 @@ jobs:
       run: |
         echo ">>> NEXT VERSION" >> $BASEDIR/logs/aws_sync.log
         aws s3 sync _site s3://$S3_BUCKET/docs/next --delete >> $BASEDIR/logs/aws_sync.log
-    - name: "Latest release: generate and validate docs for all the libraries"
-      run: |
-        export VERSION=$(grep LATEST_VERSION $BASEDIR/arrow-master/gradle.properties | cut -d= -f2)
-        git clone https://github.com/arrow-kt/arrow-site.git $BASEDIR/arrow-site-$VERSION
-        LAST_TAG=$(git tag -l --sort=version:refname ${VERSION}* | tail -1)
-        echo ">> Last tag: $LAST_TAG"
-        cd $BASEDIR/arrow-site-$VERSION; git checkout $LAST_TAG; cd -
-        ./scripts/generate-and-validate-doc.sh
-    - name: "Latest release: build"
-      run: |
-        bundle exec jekyll build -b docs -s docs
-        tree _site > $BASEDIR/logs/content_docs.log
-    - name: "Latest release: publish"
-      run: |
-        echo ">>> Latest release" >> $BASEDIR/logs/aws_sync.log
-        ./scripts/publish-latest-release.sh
-    - name: "Other versions: generate, validate, build and publish"
-      run: |
-        if [ -f $BASEDIR/arrow-site/update-other-versions.txt ]; then
-            for version in $(cat update-other-versions.txt); do
-                export VERSION=$version
-                export SHORT_VERSION=$(echo $VERSION | cut -d. -f1-2)
-                git clone https://github.com/arrow-kt/arrow-site.git $BASEDIR/arrow-site-$VERSION
-                LAST_TAG=$(git tag -l --sort=version:refname ${VERSION}* | tail -1)
-                echo ">> Last tag: $LAST_TAG"
-                cd $BASEDIR/arrow-site-$VERSION; git checkout $LAST_TAG; cd -
-                ./scripts/generate-and-validate-doc.sh
-                cd $BASEDIR/arrow-site
-                rm -f docs/index.md
-                bundle exec jekyll build -b docs/$SHORT_VERSION -s docs
-                tree _site > $BASEDIR/logs/content_docs-${SHORT_VERSION}.log
-                echo ">>> $SHORT_VERSION VERSION" >> $BASEDIR/logs/aws_sync.log
-                aws s3 sync _site s3://$S3_BUCKET/docs/$SHORT_VERSION --delete >> $BASEDIR/logs/aws_sync.log
-            done
-        fi
+    #- name: "Latest release: generate and validate docs for all the libraries"
+    #  run: |
+    #    export VERSION=$(grep LATEST_VERSION $BASEDIR/arrow-master/gradle.properties | cut -d= -f2)
+    #    git clone https://github.com/arrow-kt/arrow-site.git $BASEDIR/arrow-site-$VERSION
+    #    LAST_TAG=$(git tag -l --sort=version:refname ${VERSION}* | tail -1)
+    #    echo ">> Last tag: $LAST_TAG"
+    #    cd $BASEDIR/arrow-site-$VERSION; git checkout $LAST_TAG; cd -
+    #    ./scripts/generate-and-validate-doc.sh
+    #- name: "Latest release: build"
+    #  run: |
+    #    bundle exec jekyll build -b docs -s docs
+    #    tree _site > $BASEDIR/logs/content_docs.log
+    #- name: "Latest release: publish"
+    #  run: |
+    #    echo ">>> Latest release" >> $BASEDIR/logs/aws_sync.log
+    #    ./scripts/publish-latest-release.sh
+    #- name: "Other versions: generate, validate, build and publish"
+    #  run: |
+    #    if [ -f $BASEDIR/arrow-site/update-other-versions.txt ]; then
+    #        for version in $(cat update-other-versions.txt); do
+    #            export VERSION=$version
+    #            export SHORT_VERSION=$(echo $VERSION | cut -d. -f1-2)
+    #            git clone https://github.com/arrow-kt/arrow-site.git $BASEDIR/arrow-site-$VERSION
+    #            LAST_TAG=$(git tag -l --sort=version:refname ${VERSION}* | tail -1)
+    #            echo ">> Last tag: $LAST_TAG"
+    #            cd $BASEDIR/arrow-site-$VERSION; git checkout $LAST_TAG; cd -
+    #            ./scripts/generate-and-validate-doc.sh
+    #            cd $BASEDIR/arrow-site
+    #            rm -f docs/index.md
+    #            bundle exec jekyll build -b docs/$SHORT_VERSION -s docs
+    #            tree _site > $BASEDIR/logs/content_docs-${SHORT_VERSION}.log
+    #            echo ">>> $SHORT_VERSION VERSION" >> $BASEDIR/logs/aws_sync.log
+    #            aws s3 sync _site s3://$S3_BUCKET/docs/$SHORT_VERSION --delete >> $BASEDIR/logs/aws_sync.log
+    #        done
+    #    fi
     - name: "Site: generate sitemap.xml"
       run: |
         echo '<?xml version="1.0" encoding="UTF-8"?>' > sitemap.xml

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "jekyll", "~> 3.7.3"
+gem "jekyll", "~> 4.2.0"
 gem "jekyll-redirect-from"


### PR DESCRIPTION
To support Ruby 2.7.0 and avoid these repetitive warnings:

```
arrow-site/vendor/bundle/ruby/2.7.0/gems/jekyll-3.7.4/lib/jekyll/convertible.rb:43: warning: Using the last argument as keyword parameters is deprecated
```
```
arrow-site/vendor/bundle/ruby/2.7.0/gems/jekyll-3.7.4/lib/jekyll/tags/include.rb:191: warning: Using the last argument as keyword parameters is deprecated
```