### PR TITLE
Adapt URLs for local generation

### DIFF
--- a/docs/_data/features.yml
+++ b/docs/_data/features.yml
@@ -2,19 +2,19 @@ content:
     - title: Core
       description: Functional companion to Kotlin's Standard Library
       icon: img/home/arrow-core-lines
-      url: /docs/core/
+      url: /core/
       id: core
 
     - title: FX
       description: Functional Effects Framework companion to KotlinX Coroutines.
       icon: img/home/arrow-fx-lines
-      url: /docs/fx/
+      url: /fx/
       id: fx
 
     - title: Optics
       description: Deep access and transformations over immutable data
       icon: img/home/arrow-optics-lines
-      url: /docs/optics/dsl/
+      url: /optics/dsl/
       id: optics
 
     - title: Meta

--- a/docs/_includes/_main.html
+++ b/docs/_includes/_main.html
@@ -3,7 +3,7 @@
     <div id="main-flex" class="main-flex">
       {% for item in site.data.features.content %}
       {% assign title = item.title | downcase  %}
-      <a id="{{ item.id }}" class="{{ item.id }} main-item feature" href="{{ item.url }}">
+      <a id="{{ item.id }}" class="{{ item.id }} main-item feature" href="{{ item.url | relative_url }}">
 
         <div id="{{ item.id }}-header" class="item-header">
           <div id="icon-{{ item.id }}-content" class="icon-content">

--- a/docs/_includes/_sidebar-cat-dropdown.html
+++ b/docs/_includes/_sidebar-cat-dropdown.html
@@ -8,11 +8,10 @@
       </a>
       <ul>
         {% for item in site.data.features.content %}
-        {% assign cat_url = item.url | remove_first: '/docs' %}
         {% assign cat = item.title | downcase  %}
         {% if cat != cat_title %}
         <li>
-          <a href="{{ cat_url | relative_url }}">
+          <a href="{{ item.url | relative_url }}">
             <span>{{ item.title }}</span>
           </a>
         </li>

--- a/docs/_includes/_sidebar-wrapper.html
+++ b/docs/_includes/_sidebar-wrapper.html
@@ -7,7 +7,7 @@
   <div class="sidebar-brand">
     <a href="{{ site.data.commons.stable_version | relative_url }}">
       {% assign img_url = '/img/' | append: cat_id | append: '/arrow-' | append: cat_id | append: '-brand-sidebar.svg' %}
-      <img src="{{ img_url | relative_url}}" alt="Arrow {{ cat_id }}">
+      <img src="{{ img_url}}" alt="Arrow {{ cat_id }}">
     </a>
     {% assign cat_title = cat_id  %}
     {% include _sidebar-cat-dropdown.html %}


### PR DESCRIPTION
- Main links won't start with `/docs` and will be adapted for local generation or running website in the landing page.
- They will be adapted for local generation, release or next version in the dropdown menu.

Other changes:
- Pending image URL from #77 